### PR TITLE
Fix: average_goals_per_game methods rename

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -72,15 +72,15 @@ class StatTracker
     percentage(tied_games_count, total_games_count)
   end
 
-  # def total_goals
-  #   total_goals_count = 0.0
-  #   @games.each do |game|
-  #     total_goals_count += game.total_goals
-  #   end
-  #   total_goals_count
-  # end
+  def total_goals
+    total_goals_count = 0.0
+    @games.each do |game|
+      total_goals_count += game.total_goals
+    end
+    total_goals_count
+  end
 
-  def average_goals_across_all_games #refactor league stats average_goals_per_game to different name and rename this
+  def average_goals_per_game
     all_total_goals = @games.map {|game| game.total_goals}
     average(all_total_goals)
   end
@@ -138,7 +138,7 @@ class StatTracker
 
   def best_offense
     id = @game_teams.max_by do |team|
-      average_goals_per_game(team.team_id)
+      average_goals_per_game_by_team(team.team_id)
     end.team_id
 
     @teams.find do |team|
@@ -160,13 +160,13 @@ class StatTracker
     goals.sum
   end
 
-  def average_goals_per_game(team_id)
+  def average_goals_per_game_by_team(team_id)
     total_goals_by_team(team_id).to_f / games_by_team(team_id).length.to_f
   end
 
   def worst_offense
     id = @game_teams.min_by do |team|
-      average_goals_per_game(team.team_id)
+      average_goals_per_game_by_team(team.team_id)
     end.team_id
 
     @teams.find do |team|

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -112,19 +112,19 @@ RSpec.describe StatTracker do
     end
   end
 
-  # describe '#total_goals' do
-  #   it 'counts the total number of away_goals and home_goals' do
-  #     expect(@stat_tracker.total_goals).to be_an_instance_of Float
-  #
-  #     expect(@stat_tracker.total_goals).to eq 31413.0
-  #   end
-  # end
+  describe '#total_goals' do
+    it 'counts the total number of away_goals and home_goals' do
+      expect(@stat_tracker.total_goals).to be_an_instance_of Float
 
-  describe '#average_goals_across_all_games' do
+      expect(@stat_tracker.total_goals).to eq 31413.0
+    end
+  end
+
+  describe '#average_goals_per_game' do
     it 'divides the total number of goals by the total number of games' do
-      expect(@stat_tracker.average_goals_across_all_games).to be_an_instance_of Float #refactor league stats average_goals_per_game to different name and rename this
+      expect(@stat_tracker.average_goals_per_game).to be_an_instance_of Float
 
-      expect(@stat_tracker.average_goals_across_all_games).to eq 4.22 #refactor league stats average_goals_per_game to different name and rename this
+      expect(@stat_tracker.average_goals_per_game).to eq 4.22
     end
   end
 
@@ -135,7 +135,6 @@ RSpec.describe StatTracker do
     end
 
     it 'has helper get_season_ids' do
-      # require "pry"; binding.pry
       expect(@stat_tracker.get_season_ids).to be_an_instance_of Array
 
       expect(@stat_tracker.get_season_ids).to include("20132014")
@@ -210,15 +209,15 @@ RSpec.describe StatTracker do
     end
   end
 
-  describe '#total goals_by_team' do
+  describe '#total_goals_by_team' do
     it 'returns number of total goals by team_id' do
       expect(@stat_tracker.total_goals_by_team(3)).to eq(8)
     end
   end
 
-  describe '#average_goals_per_game' do
+  describe '#average_goals_per_game_by_team' do
     it 'returns number of average goals per game by team_id' do
-      expect(@stat_tracker.average_goals_per_game(3)).to eq(1.6)
+      expect(@stat_tracker.average_goals_per_game_by_team(3)).to eq(1.6)
     end
   end
 


### PR DESCRIPTION
This fix includes: 
-Rename method to correct average_goals_per_game
-Rename league helper to average_goals_per_game_by_team 
-Update method names where they are called within stat_tracker
-Update method names where they are called within stat_tracker_spec